### PR TITLE
drivers/at86rf2xx: Driver Adaptations for confirm_send()

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -122,6 +122,7 @@ void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params, uint8_t
     dev->idle_state = AT86RF2XX_STATE_TRX_OFF;
     /* radio state is P_ON when first powered-on */
     dev->state = AT86RF2XX_STATE_P_ON;
+    dev->status = 0;
     dev->pending_tx = 0;
 
 #if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
@@ -287,8 +288,6 @@ size_t at86rf2xx_tx_load(at86rf2xx_t *dev, const uint8_t *data,
 
 void at86rf2xx_tx_exec(at86rf2xx_t *dev)
 {
-    netdev_t *netdev = (netdev_t *)dev;
-
 #if AT86RF2XX_HAVE_RETRIES
     dev->tx_retries = -1;
 #endif
@@ -298,9 +297,6 @@ void at86rf2xx_tx_exec(at86rf2xx_t *dev)
     /* trigger sending of pre-loaded frame */
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_STATE,
                         AT86RF2XX_TRX_STATE__TX_START);
-    if (netdev->event_callback) {
-        netdev->event_callback(netdev, NETDEV_EVENT_TX_STARTED);
-    }
 }
 
 bool at86rf2xx_cca(at86rf2xx_t *dev)

--- a/drivers/at86rf2xx/at86rf2xx_internal.c
+++ b/drivers/at86rf2xx/at86rf2xx_internal.c
@@ -116,6 +116,16 @@ uint8_t at86rf2xx_get_status(const at86rf2xx_t *dev)
             & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS);
 }
 
+bool at86rf2xx_is_busy(const at86rf2xx_t *dev)
+{
+    uint8_t s;
+    while ((s = at86rf2xx_get_status(dev)) == AT86RF2XX_STATE_IN_PROGRESS) {}
+    return s == AT86RF2XX_STATE_BUSY_RX         ||
+           s == AT86RF2XX_STATE_BUSY_TX         ||
+           s == AT86RF2XX_STATE_BUSY_RX_AACK    ||
+           s == AT86RF2XX_STATE_BUSY_TX_ARET;
+}
+
 void at86rf2xx_assert_awake(at86rf2xx_t *dev)
 {
     if (at86rf2xx_get_status(dev) == AT86RF2XX_STATE_SLEEP) {

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -47,6 +47,7 @@
 #include "debug.h"
 
 static int _send(netdev_t *netdev, const iolist_t *iolist);
+static int _confirm_send(netdev_t *netdev, void *info);
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info);
 static int _init(netdev_t *netdev);
 static void _isr(netdev_t *netdev);
@@ -55,6 +56,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len);
 
 const netdev_driver_t at86rf2xx_driver = {
     .send = _send,
+    .confirm_send = _confirm_send,
     .recv = _recv,
     .init = _init,
     .isr = _isr,
@@ -71,6 +73,16 @@ static void _irq_handler(void *arg)
     netdev_trigger_event_isr(arg);
 }
 #endif
+
+static inline void _tigger_send(at86rf2xx_t *dev)
+{
+    netdev_t *netdev = &dev->netdev.netdev;
+    at86rf2xx_tx_exec(dev);
+    dev->status = AT86RF2XX_TRX_STATE__TRAC_INVALID;
+    if (netdev->event_callback) {
+        netdev->event_callback(&dev->netdev.netdev, NETDEV_EVENT_TX_STARTED);
+    }
+}
 
 static int _init(netdev_t *netdev)
 {
@@ -117,6 +129,10 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     at86rf2xx_t *dev = (at86rf2xx_t *)netdev;
     size_t len = 0;
 
+    if (at86rf2xx_is_busy(dev)) {
+        return -EBUSY;
+    }
+
     at86rf2xx_tx_prepare(dev);
 
     /* load packet data into FIFO */
@@ -134,11 +150,42 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
 
     /* send data out directly if pre-loading id disabled */
     if (!(dev->flags & AT86RF2XX_OPT_PRELOADING)) {
-        at86rf2xx_tx_exec(dev);
+        _tigger_send(dev);
     }
     /* return the number of bytes that were actually loaded into the frame
      * buffer/send out */
     return (int)len;
+}
+
+static int _confirm_send(netdev_t *netdev, void *info)
+{
+    (void)info;
+    at86rf2xx_t *dev = (at86rf2xx_t *)netdev;
+    int ret;
+
+    /* ISR sets this */
+    switch (dev->status) {
+        case AT86RF2XX_TRX_STATE__TRAC_SUCCESS:
+        case AT86RF2XX_TRX_STATE__TRAC_SUCCESS_DATA_PENDING:
+            ret = dev->tx_frame_len;
+            break;
+        case AT86RF2XX_TRX_STATE__TRAC_CHANNEL_ACCESS_FAILURE:
+            ret = -EBUSY;
+            break;
+        case AT86RF2XX_TRX_STATE__TRAC_NO_ACK:
+            ret = -ECOMM;
+            break;
+        case AT86RF2XX_TRX_STATE__TRAC_INVALID:
+            /* Even though the reset value for register bits TRAC_STATUS
+               is zero, the RX_AACK and TX_ARET procedures set the register
+               bits to TRAC_STATUS = 7 (INVALID) when they are started. */
+            ret = -EAGAIN;
+            break;
+        default:
+            DEBUG("[at86rf2xx] unknown status %u\n", dev->status);
+            ret = 0;
+    }
+    return ret;
 }
 
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
@@ -272,7 +319,7 @@ static int _set_state(at86rf2xx_t *dev, netopt_state_t state)
                     ++dev->pending_tx;
                 }
                 at86rf2xx_set_state(dev, AT86RF2XX_PHY_STATE_TX);
-                at86rf2xx_tx_exec(dev);
+                _tigger_send(dev);
             }
             break;
         case NETOPT_STATE_RESET:
@@ -663,53 +710,25 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
     return res;
 }
 
-static void _isr_send_complete(at86rf2xx_t *dev, uint8_t trac_status)
+static void _isr_send_complete(at86rf2xx_t *dev)
 {
     netdev_t *netdev = &dev->netdev.netdev;
     if (IS_ACTIVE(AT86RF2XX_BASIC_MODE)) {
-        netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
-        return;
+        dev->status = AT86RF2XX_TRX_STATE__TRAC_SUCCESS;
     }
-/* Only radios with the XAH_CTRL_2 register support frame retry reporting */
+    else {
+    /* Only radios with the XAH_CTRL_2 register support frame retry reporting */
 #if AT86RF2XX_HAVE_RETRIES && defined(AT86RF2XX_REG__XAH_CTRL_2)
-    dev->tx_retries = (at86rf2xx_reg_read(dev, AT86RF2XX_REG__XAH_CTRL_2)
-                       & AT86RF2XX_XAH_CTRL_2__ARET_FRAME_RETRIES_MASK) >>
-                      AT86RF2XX_XAH_CTRL_2__ARET_FRAME_RETRIES_OFFSET;
+        dev->tx_retries = at86rf2xx_reg_read(dev, AT86RF2XX_REG__XAH_CTRL_2);
+        dev->tx_retries &= AT86RF2XX_XAH_CTRL_2__ARET_FRAME_RETRIES_MASK;
+        dev->tx_retries >>= AT86RF2XX_XAH_CTRL_2__ARET_FRAME_RETRIES_OFFSET;
 #endif
-
-    DEBUG("[at86rf2xx] EVT - TX_END\n");
+    }
 
     if (netdev->event_callback) {
-        switch (trac_status) {
-#ifdef MODULE_OPENTHREAD
-            case AT86RF2XX_TRX_STATE__TRAC_SUCCESS:
-                netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
-                DEBUG("[at86rf2xx] TX SUCCESS\n");
-                break;
-            case AT86RF2XX_TRX_STATE__TRAC_SUCCESS_DATA_PENDING:
-                netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE_DATA_PENDING);
-                DEBUG("[at86rf2xx] TX SUCCESS DATA PENDING\n");
-                break;
-#else
-                    case AT86RF2XX_TRX_STATE__TRAC_SUCCESS:
-                    case AT86RF2XX_TRX_STATE__TRAC_SUCCESS_DATA_PENDING:
-                        netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
-                        DEBUG("[at86rf2xx] TX SUCCESS\n");
-                        break;
-#endif
-                    case AT86RF2XX_TRX_STATE__TRAC_NO_ACK:
-                        netdev->event_callback(netdev, NETDEV_EVENT_TX_NOACK);
-                        DEBUG("[at86rf2xx] TX NO_ACK\n");
-                        break;
-                    case AT86RF2XX_TRX_STATE__TRAC_CHANNEL_ACCESS_FAILURE:
-                        netdev->event_callback(netdev, NETDEV_EVENT_TX_MEDIUM_BUSY);
-                        DEBUG("[at86rf2xx] TX_CHANNEL_ACCESS_FAILURE\n");
-                        break;
-                    default:
-                        DEBUG("[at86rf2xx] Unhandled TRAC_STATUS: %d\n",
-                              trac_status >> 5);
-                }
-            }
+        /* let _confirm_send() evaluate the transmission status */
+        netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
+    }
 }
 
 static inline void _isr_recv_complete(netdev_t *netdev)
@@ -739,7 +758,6 @@ static void _isr(netdev_t *netdev)
     at86rf2xx_t *dev = (at86rf2xx_t *) netdev;
     uint8_t irq_mask;
     uint8_t state;
-    uint8_t trac_status;
 
     /* If transceiver is sleeping register access is impossible and frames are
      * lost anyway, so return immediately.
@@ -757,31 +775,30 @@ static void _isr(netdev_t *netdev)
     irq_mask = at86rf2xx_reg_read(dev, AT86RF2XX_REG__IRQ_STATUS);
 #endif
 
-    trac_status = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATE)
-                  & AT86RF2XX_TRX_STATE_MASK__TRAC;
-
     if (irq_mask & AT86RF2XX_IRQ_STATUS_MASK__RX_START) {
-        netdev->event_callback(netdev, NETDEV_EVENT_RX_STARTED);
+        if (netdev->event_callback) {
+            netdev->event_callback(netdev, NETDEV_EVENT_RX_STARTED);
+        }
         DEBUG("[at86rf2xx] EVT - RX_START\n");
     }
 
     if (irq_mask & AT86RF2XX_IRQ_STATUS_MASK__TRX_END) {
+        if (!IS_ACTIVE(AT86RF2XX_BASIC_MODE)) {
+            dev->status = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATE)
+                          & AT86RF2XX_TRX_STATE_MASK__TRAC;
+        }
         if ((state == AT86RF2XX_PHY_STATE_RX)
             || (state == AT86RF2XX_PHY_STATE_RX_BUSY)) {
             DEBUG("[at86rf2xx] EVT - RX_END\n");
-
             _isr_recv_complete(netdev);
-
         }
         else if (state == AT86RF2XX_PHY_STATE_TX) {
-            /* check for more pending TX calls and return to idle state if
-             * there are none */
-            assert(dev->pending_tx != 0);
             /* Radio is idle, any TX transaction is done */
+            assert(dev->pending_tx != 0);
             dev->pending_tx = 0;
             at86rf2xx_set_state(dev, dev->idle_state);
             DEBUG("[at86rf2xx] return to idle state 0x%x\n", dev->idle_state);
-            _isr_send_complete(dev, trac_status);
+            _isr_send_complete(dev);
         }
         /* Only the case when an interrupt was received and the radio is busy
          * with a next PDU transmission when _isr is called.
@@ -794,7 +811,7 @@ static void _isr(netdev_t *netdev)
         else if (state == AT86RF2XX_PHY_STATE_TX_BUSY) {
             if (dev->pending_tx > 1) {
                 dev->pending_tx--;
-                _isr_send_complete(dev, trac_status);
+                _isr_send_complete(dev);
             }
         }
     }

--- a/drivers/at86rf2xx/include/at86rf2xx_internal.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_internal.h
@@ -24,6 +24,7 @@
 #ifndef AT86RF2XX_INTERNAL_H
 #define AT86RF2XX_INTERNAL_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "at86rf2xx.h"
@@ -202,6 +203,15 @@ void at86rf2xx_fb_stop(const at86rf2xx_t *dev);
  * @return              internal status of the given device
  */
 uint8_t at86rf2xx_get_status(const at86rf2xx_t *dev);
+
+/**
+ * @brief   Check whether the transceiver is currently in a busy state
+ *
+ * @param[in] dev       device to check for being busy
+ *
+ * @return              true if device is busy, else false
+ */
+bool at86rf2xx_is_busy(const at86rf2xx_t *dev);
 
 /**
  * @brief   Make sure that device is not sleeping

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -251,6 +251,7 @@ typedef struct {
     uint16_t flags;                         /**< Device specific flags */
     uint8_t state;                          /**< current state of the radio */
     uint8_t tx_frame_len;                   /**< length of the current TX frame */
+    uint8_t status;                         /**< Tx/Rx status (TRAC_STATUS) */
 #ifdef MODULE_AT86RF212B
     /* Only AT86RF212B supports multiple pages (PHY modes) */
     uint8_t page;                       /**< currently used channel page */

--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -385,8 +385,10 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     res = dev->driver->send(dev, &iolist_header);
 #endif
 
-    /* release old data */
-    gnrc_pktbuf_release(pkt);
+    if (!dev->driver->confirm_send) {
+        /* only for legacy drivers we need to release pkt here */
+        gnrc_pktbuf_release(pkt);
+    }
     return res;
 }
 /** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The PR modifies the `at86rf2xx` driver to  be used with the new  `confirm_send()` API.
- create a `netdev_driver_t::confirm_send()`
- do not block in `netdev_driver_t::send()`

The event `NETDEV_EVENT_TX_COMPLETE` is triggered, as before, in the `_isr()` function of the driver.
If an IPC  `SND` message is received before `confirm_send()` could destroy the previous frame, `gnrc_netif_pktq` is required.
If this is what you expect and you don´t want to merge it into your local `confirm_send` branch, then I could open the PR in RIOT and make it depend on #15821.
But I am not sure if the changes are sufficient. Especially because the driver would now depend on the packet queue.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
```
> ping6 fe80::fc0f:9087:caff:ef38 -s 1024
2021-03-09 11:51:52,268 # ping6 fe80::fc0f:9087:caff:ef38 -s 1024
2021-03-09 11:51:52,418 # 1032 bytes from fe80::fc0f:9087:caff:ef38%6: icmp_seq=0 ttl=64 rssi=-65 dBm time=143.490 ms
2021-03-09 11:51:53,409 # 1032 bytes from fe80::fc0f:9087:caff:ef38%6: icmp_seq=1 ttl=64 rssi=-65 dBm time=143.786 ms
2021-03-09 11:51:54,401 # 1032 bytes from fe80::fc0f:9087:caff:ef38%6: icmp_seq=2 ttl=64 rssi=-65 dBm time=144.480 ms
2021-03-09 11:51:54,401 # 
2021-03-09 11:51:54,405 # --- fe80::fc0f:9087:caff:ef38 PING statistics ---
2021-03-09 11:51:54,410 # 3 packets transmitted, 3 packets received, 0% packet loss
2021-03-09 11:51:54,415 # round-trip min/avg/max = 143.490/143.918/144.480 ms
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
